### PR TITLE
fix: backup storage flag

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -85,6 +85,7 @@ export async function createAgent() {
       // FIXME: We should probably remove this at some point, but it will require custom logic
       // Also, doesn't work with multi-tenancy yet
       autoUpdateStorageOnStartup: true,
+      backupBeforeStorageUpdate: false,
       didCommMimeType: DidCommMimeType.V0,
     },
     dependencies: agentDependencies,


### PR DESCRIPTION
### Summary

- Added `backupBeforeStorageUpdate` flag as `false` as it is not supported for storage type `postgres`